### PR TITLE
Open new shttp client per request

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -261,16 +261,14 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
-			"checksumSHA1": "/CGpKuEq96RUMaRZhPgGaZ82bB0=",
+			"checksumSHA1": "aTl0eTEuxfbgAlwYHXGILcHHZTs=",
 			"path": "github.com/netsec-ethz/scion-apps/lib/scionutil",
-			"revision": "87c9760d4863e225f358617c983bca9e67e687f7",
-			"revisionTime": "2019-02-15T15:48:15Z"
+			"revision": "f62c8b69df3cef78dc62a2cfe82d6339d4882906"
 		},
 		{
-			"checksumSHA1": "QQTZfjwkPnQ0e1tgaQ4bjkT5TSI=",
+			"checksumSHA1": "/Y3PL8T9upUZiRnA9qWnG7bX/PE=",
 			"path": "github.com/netsec-ethz/scion-apps/lib/shttp",
-			"revision": "87c9760d4863e225f358617c983bca9e67e687f7",
-			"revisionTime": "2019-02-15T15:48:15Z"
+			"revision": "f62c8b69df3cef78dc62a2cfe82d6339d4882906"
 		},
 		{
 			"checksumSHA1": "W8mzTLRjnooGtHwWaxSX8eq8hlY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -261,14 +261,14 @@
 			"revisionTime": "2016-04-24T11:30:07Z"
 		},
 		{
-			"checksumSHA1": "aTl0eTEuxfbgAlwYHXGILcHHZTs=",
+			"checksumSHA1": "AajIKc7M2kvv4FSGHrDzCJ0BpHk=",
 			"path": "github.com/netsec-ethz/scion-apps/lib/scionutil",
-			"revision": "f62c8b69df3cef78dc62a2cfe82d6339d4882906"
+			"revision": "c7a9fed692ccad46430e2da0d317fa5780b78f7b"
 		},
 		{
-			"checksumSHA1": "/Y3PL8T9upUZiRnA9qWnG7bX/PE=",
+			"checksumSHA1": "WKuXuQAWxTWqo575gP5UHJ0jDSY=",
 			"path": "github.com/netsec-ethz/scion-apps/lib/shttp",
-			"revision": "f62c8b69df3cef78dc62a2cfe82d6339d4882906"
+			"revision": "c7a9fed692ccad46430e2da0d317fa5780b78f7b"
 		},
 		{
 			"checksumSHA1": "W8mzTLRjnooGtHwWaxSX8eq8hlY=",


### PR DESCRIPTION
This avoids trying to use stale snet-connections. This seems to work reasonably reliably with latest version of shttp with fixes for `Close`-ing the connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/2sms/91)
<!-- Reviewable:end -->
